### PR TITLE
Pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/build-deploy-and-tag-ecr-image.yml
+++ b/.github/workflows/build-deploy-and-tag-ecr-image.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   ecr-deploy:
-    uses: nationalarchives/da-tre-github-actions/.github/workflows/docker-build-and-ecr-deploy-with-wiz-scan.yml@0.0.80
+    uses: nationalarchives/da-tre-github-actions/.github/workflows/docker-build-and-ecr-deploy-with-wiz-scan.yml@e5261245e37488b920d48c7821a83e3030b21db4 # 0.0.80
     with:
       docker_image_name: 'da-tre-fn-success-destination'
       build_dir: '.'


### PR DESCRIPTION
This PR pins third-party GitHub Actions to full commit SHAs for supply-chain security.

This has been done automatically by [pinact](https://github.com/suzuki-shunsuke/pinact). When reviewing please confirm that the SHAs are correct, zizmor will alert if not.

As a maintainer, please merge this PR once approved.